### PR TITLE
Add support for jdk1.8

### DIFF
--- a/lib/jvm_gclog.rb
+++ b/lib/jvm_gclog.rb
@@ -4,7 +4,7 @@ class JVMGCLog
   def initialize
     @regexp_prefix = Regexp.compile('^(?<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+\+\d{4}): (?<uptime>\d+\.\d*): ')
   end
-  
+
   def adjust_type(value)
     if value =~ /^\d+\.\d+$/
       return value.to_f
@@ -21,11 +21,11 @@ class JVMGCLog
     else
       m.names.each {|name|
         record[name] = adjust_type(m[name])
-      }    
+      }
     end
     record
   end
-  
+
   def recognize_chunks(lines)
     chunks = []
 
@@ -101,12 +101,12 @@ class JVMGCLog
       record.update(match_fields_to_hash(m))
       record["type"] = "YoungGC"
 
-    when /^\[GC \[PSYoungGen: (?<new_before>\d+)K-\>(?<new_after>\d+)K\((?<new_total>\d+)K\)\] (?<heap_before>\d+)K\-\>(?<heap_after>\d+)K\((?<heap_total>\d+)K\), (?<gctime>[\d\.]+) secs\]/
+    when /^\[GC.+\[PSYoungGen: (?<new_before>\d+)K-\>(?<new_after>\d+)K\((?<new_total>\d+)K\)\] (?<heap_before>\d+)K\-\>(?<heap_after>\d+)K\((?<heap_total>\d+)K\), (?<gctime>[\d\.]+) secs\]/
       m = Regexp.last_match
       record.update(match_fields_to_hash(m))
       record["type"] = "YoungGC"
-      
-    when /^\[GC \[1 CMS-initial-mark: (?<old_before>\d+)K\((?<old_threshold>\d+)K\)\] (?<heap_before>\d+)K\((?<heap_total>\d+)K\), (?<gctime>[\d\.]+) secs\]/
+
+    when /^\[GC.+\[1 CMS-initial-mark: (?<old_before>\d+)K\((?<old_threshold>\d+)K\)\] (?<heap_before>\d+)K\((?<heap_total>\d+)K\), (?<gctime>[\d\.]+) secs\]/
       m = Regexp.last_match
       record.update(match_fields_to_hash(m))
       record["type"] = "CMS-initial-mark"


### PR DESCRIPTION
This change supports newer version of SDK with such lines:
`2016-07-05T12:27:09.243+0000: 156671.412: [GC (Allocation Failure) [PSYoungGen: 11062902K->65313K(11272704K)] 19331147K->8357229K(24904192K), 0.0491835 secs] [Times: user=0.39 sys=0.00, real=0.05 secs]`

If you still are using this plugin, can you create some tests? To make extending supported formats safer? (I'm not familiar with Ruby test frameworks at all).