### PR TITLE
Fix the pattern match reminder check

### DIFF
--- a/lib/jvm_gclog.rb
+++ b/lib/jvm_gclog.rb
@@ -135,7 +135,7 @@ class JVMGCLog
       record["unknown"] = body
     end
 
-    if m = $'.match('\[Times: user=(?<gctime_user>[\d\.]+) sys=(?<gctime_sys>[\d\.]+), real=(?<gctime_real>[\d\.]+) secs\]')
+    if $' != nil && m = $'.match('\[Times: user=(?<gctime_user>[\d\.]+) sys=(?<gctime_sys>[\d\.]+), real=(?<gctime_real>[\d\.]+) secs\]')
       record.update(match_fields_to_hash(m))
     end
 


### PR DESCRIPTION
From the definition:
$' - The string following whatever was matched by the last successful pattern match in the current scope, or nil if the last pattern match failed. (Mnemonic: ' often follows a quoted string.)

Additional check for nil for failed matches. 